### PR TITLE
Validate command not only exists but was used

### DIFF
--- a/skele/cli.py
+++ b/skele/cli.py
@@ -34,7 +34,7 @@ def main():
     # Here we'll try to dynamically match the command the user is trying to run
     # with a pre-defined command class we've already created.
     for k, v in options.iteritems():
-        if hasattr(commands, k):
+        if hasattr(commands, k) and v:
             module = getattr(commands, k)
             commands = getmembers(module, isclass)
             command = [command[1] for command in commands if command[0] != 'Base'][0]


### PR DESCRIPTION
Without this, it just uses the first command module that exists, even if that option is `False` (it wasn't passed by the user)
