### PR TITLE
Removes an exclusion from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,4 @@ prune .cache
 prune .git
 prune build
 prune dist
-recursive-exclude *.egg-info *
 recursive-include tests *


### PR DESCRIPTION
When the line is included and `python setup.py install` is run, the exclusion
prevents setuptools from installing the entry point console_scripts
correctly.  Removing this line works in 2019.